### PR TITLE
added rules to .eslintrc file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
     "rules": {
         // error if no semi included
         "semi": [2, "always"], 
-        // warn on single quotes
+        // warn on double quotes
         "quotes": [1, "double"], 
         // error if function args repeat
         "no-dupe-args": [2], 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,5 +9,23 @@
         "sourceType": "module"
     },
     "rules": {
+        // error if no semi included
+        "semi": [2, "always"], 
+        // warn on single quotes
+        "quotes": [1, "double"], 
+        // error if function args repeat
+        "no-dupe-args": [2], 
+        // warns if imports are not succient
+        "no-duplicate-imports": [1, {"includeExports": true }],
+        // warns if code is unreachable
+        "no-unreachable": 1,
+        // prevent global declarations
+        "no-implicit-globals": 2,
+        // warns on inline comments
+        "no-inline-comments": 1,
+        // error when using var
+        "no-var": 2,
+        // warns if async does  not have an await
+        "require-await": 1
     }
 }


### PR DESCRIPTION
- modified rules for eslint
    - warnings:
        - double quotes
        - duplicate imports
        - inline comments
        - no await within an async function
    - errors:
        - no semicolon
        - duplicate arguments
        - global declarations
        - using var for a variable